### PR TITLE
[HOPSWORKS-1163] Allow explicit setting of the Jupyter token

### DIFF
--- a/templates/default/jupyter-launch.sh.erb
+++ b/templates/default/jupyter-launch.sh.erb
@@ -9,10 +9,11 @@ PORT=$5
 LOGFILE=${JUPYTER_HOME}/logs/$6
 SECRET_DIR=$7
 CERTS_DIR=$8
+TOKEN=${10}
 
 help() {
     echo ""
-    echo "usage: $0 JUPYTER_HOME HADOOP_HOME ANACONDA_ENV PORT LOGFILE SECRET_DIR CERTS_DIR HADOOP_USERNAME"
+    echo "usage: $0 JUPYTER_HOME HADOOP_HOME ANACONDA_ENV PORT LOGFILE SECRET_DIR CERTS_DIR HADOOP_USERNAME TOKEN"
     echo ""
     exit 1
 }
@@ -28,7 +29,7 @@ function kill_named {
     return "$res"
 }
 
-if [ $# -ne 9 ]; then
+if [ $# -ne 10 ]; then
   help
 fi
 
@@ -74,19 +75,19 @@ ln -s /usr/local/share/jupyter/nbextensions/facets-dist nbextensions/facets-dist
 cd "$SECRET_DIR" || exit
 
 # setsid works, and 'nohup' doesnt work as nohup processes cant write their stderr/stdout to the logfile 
-setsid ${ANACONDA_ENV}/bin/jupyter notebook --debug --no-browser --NotebookApp.port="$PORT" </dev/zero &> "$LOGFILE"  &
+setsid ${ANACONDA_ENV}/bin/jupyter notebook --debug --no-browser --NotebookApp.port="$PORT" --NotebookApp.token="$TOKEN" </dev/zero &> "$LOGFILE"  &
 echo $! > "$PID_FILE"
 
-# Check that the token is written to the logfile, return when we see it.
+# Wait for jupyter to start
 timeout=0
 while [ $timeout -lt $WAIT_START ] ; do
-	sleep 1
-	grep 'token' "$LOGFILE"
-        if [ $? -eq 0 ] ; then 
+  sleep 1
+  grep 'The Jupyter Notebook is running at' "$LOGFILE"
+        if [ $? -eq 0 ] ; then
           break
         fi
-	echo -n "."
-	timeout=$((timeout + 1))
+  echo -n "."
+  timeout=$((timeout + 1))
 done
 echo ""
 

--- a/templates/default/jupyter.sh.erb
+++ b/templates/default/jupyter.sh.erb
@@ -8,7 +8,7 @@
 
 help() {
     echo ""
-    echo "usage: $0 [start jupyter_home hadoop_home java_home anaconda_env port logfile secret_dir certs_dir hadoop_username] | [kill jupyter_home pid port] | [ping pid] | [list] | [kernel-add jupyter_home  project_user conda_environment] [kernel-remove project_user]"
+    echo "usage: $0 [start jupyter_home hadoop_home java_home anaconda_env port logfile secret_dir certs_dir hadoop_username token] | [kill jupyter_home pid port] | [ping pid] | [list] | [kernel-add jupyter_home  project_user conda_environment] [kernel-remove project_user]"
     echo ""
     exit 1
 }
@@ -60,7 +60,7 @@ if [ "$1" == "kill" ] ; then
     
 elif [ "$1" == "start" ] ; then
 
-    if [ $# -ne 10 ]; then
+    if [ $# -ne 11 ]; then
 	help
     fi
 
@@ -133,7 +133,7 @@ elif [ "$1" == "start" ] ; then
     sudo chmod -R 770 "$2"
      
     # Launch the jupyter notebook
-    su "${JUPYTER_USER}" -c "${DOMAINS_DIR}/domain1/bin/jupyter-launch.sh $2 $3 $4 $5 $6 $7 $8 $9 ${10}"
+    su "${JUPYTER_USER}" -c "${DOMAINS_DIR}/domain1/bin/jupyter-launch.sh $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11}"
 
 elif [ "$1" == "ping" ] ; then
     if [ $# -ne 2 ]; then


### PR DESCRIPTION
Add the token to be used by Jupyter as an argument to allow it to be explicitly set instead of reading it from log files.

This is part of a larger Hopsworks refactoring and needs to be shipped together.