### PR TITLE
[HOPSWORKS-1357][HOPSWORKS-1358]

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,8 +39,7 @@ default['glassfish']['version']                  = '4.1.2.181'  # '5.182'
 default['authbind']['download_url']              = "#{node['download_url']}/authbind-2.1.2-0.1.x86_64.rpm"
 
 default['hopsworks']['dir']                      = node['install']['dir'].empty? ? "/usr/local" : node['install']['dir']
-default['glassfish']['install_dir']              = node['hopsworks']['dir']
-default['glassfish']['base_dir']                 = node['glassfish']['install_dir'] + "/glassfish"
+default['glassfish']['base_dir']                 = node['hopsworks']['dir'] + "/glassfish"
 default['hopsworks']['domains_dir']              = node['install']['dir'].empty? ? node['hopsworks']['dir'] + "/domains" : node['install']['dir'] + "/domains"
 default['hopsworks']['domain_name']              = "domain1"
 default['glassfish']['domains_dir']              = node['hopsworks']['domains_dir']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,7 +39,8 @@ default['glassfish']['version']                  = '4.1.2.181'  # '5.182'
 default['authbind']['download_url']              = "#{node['download_url']}/authbind-2.1.2-0.1.x86_64.rpm"
 
 default['hopsworks']['dir']                      = node['install']['dir'].empty? ? "/usr/local" : node['install']['dir']
-default['glassfish']['base_dir']                 = node['hopsworks']['dir'] + "/glassfish"
+default['glassfish']['install_dir']              = node['hopsworks']['dir']
+default['glassfish']['base_dir']                 = node['glassfish']['install_dir'] + "/glassfish"
 default['hopsworks']['domains_dir']              = node['install']['dir'].empty? ? node['hopsworks']['dir'] + "/domains" : node['install']['dir'] + "/domains"
 default['hopsworks']['domain_name']              = "domain1"
 default['glassfish']['domains_dir']              = node['hopsworks']['domains_dir']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,13 +12,6 @@ if node['hopsworks']['dela']['enabled'] == "true"
   end
 end
 
-# If the install.rb recipe was in a different run, the location of the install dir may
-# not be correct. install_dir is updated by install.rb, but not persisted, so we need to
-# reset it
-if node['glassfish']['install_dir'].include?("versions") == false
-  node.override['glassfish']['install_dir'] = "#{node['glassfish']['install_dir']}/glassfish/versions/current"
-end
-
 public_ip=my_public_ip()
 hopsworks_db = "hopsworks"
 realmname = "kthfsrealm"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -350,7 +350,7 @@ for version in versions do
   end
 end
 
-if !current_version.eql?("") && current_version < "0.6.0"
+if !current_version.eql?("") && Gem::Version.new(current_version) < Gem::Version.new('0.6.0')
  cookbook_file "#{theDomain}/flyway/sql/flyway_schema_history_0.6.0.sql" do
   source "sql/flyway_schema_history_0.6.0.sql"
   owner node['glassfish']['user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,10 @@ include_recipe "java"
 
 domain_name= node['hopsworks']['domain_name']
 domains_dir = node['hopsworks']['domains_dir']
+# This is set correctly in hopsworks::install by the chef-glassfish recipe. As each recipe has it's own 
+# instance of chef we need to re-set it here.
+# If you set it in the attributes it will break glassfish installation.
+node.override['glassfish']['install_dir'] = "#{node['glassfish']['install_dir']}/glassfish/versions/current"
 theDomain="#{domains_dir}/#{domain_name}"
 
 if node['hopsworks']['dela']['enabled'] == "true"


### PR DESCRIPTION
[HOPSWORKS-1357] flyway_schema_history fix for versions < 0.6 doesn't work after 1.0.0
[HOPSWORKS-1358] Handle glassfish upgrade from 4.1.2.174 to 4.1.2.181

[HOPSWORKS-1357]: https://logicalclocks.atlassian.net/browse/HOPSWORKS-1357
[HOPSWORKS-1358]: https://logicalclocks.atlassian.net/browse/HOPSWORKS-1358