### PR TITLE
[HOPSWORKS-1678] Extend training dataset endpoint to save train-test split information as metadata

### DIFF
--- a/files/default/sql/ddl/1.3.0__initial_tables.sql
+++ b/files/default/sql/ddl/1.3.0__initial_tables.sql
@@ -1532,6 +1532,7 @@ CREATE TABLE `training_dataset` (
   `hopsfs_training_dataset_id` INT(11) NULL,
   `external_training_dataset_id` INT(11) NULL,
   `training_dataset_type`   INT(11) NOT NULL DEFAULT '0',
+  `seed` INT(11) NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name_version` (`feature_store_id`, `name`, `version`),
   KEY `feature_store_id` (`feature_store_id`),
@@ -1564,6 +1565,23 @@ CREATE TABLE `feature_store_feature` (
   KEY `on_demand_feature_group_fk` (`on_demand_feature_group_id`),
   CONSTRAINT `FK_812_1043` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `on_demand_feature_group_fk` FOREIGN KEY (`on_demand_feature_group_id`) REFERENCES `on_demand_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `training_dataset_split`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE IF NOT EXISTS `training_dataset_split` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `training_dataset_id` int(11) NOT NULL,
+  `name` varchar(1000) COLLATE latin1_general_cs NOT NULL,
+  `percentage` float NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `training_dataset_id` (`training_dataset_id`),
+  CONSTRAINT `training_dataset_fk` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/files/default/sql/ddl/1.3.0__initial_tables.sql
+++ b/files/default/sql/ddl/1.3.0__initial_tables.sql
@@ -1532,7 +1532,7 @@ CREATE TABLE `training_dataset` (
   `hopsfs_training_dataset_id` INT(11) NULL,
   `external_training_dataset_id` INT(11) NULL,
   `training_dataset_type`   INT(11) NOT NULL DEFAULT '0',
-  `seed` INT(11) NULL,
+  `seed` BIGINT(11) NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name_version` (`feature_store_id`, `name`, `version`),
   KEY `feature_store_id` (`feature_store_id`),

--- a/files/default/sql/ddl/1.3.0__initial_tables.sql
+++ b/files/default/sql/ddl/1.3.0__initial_tables.sql
@@ -1577,7 +1577,7 @@ CREATE TABLE `feature_store_feature` (
 CREATE TABLE IF NOT EXISTS `training_dataset_split` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `training_dataset_id` int(11) NOT NULL,
-  `name` varchar(1000) COLLATE latin1_general_cs NOT NULL,
+  `name` varchar(63) COLLATE latin1_general_cs NOT NULL,
   `percentage` float NOT NULL,
   PRIMARY KEY (`id`),
   KEY `training_dataset_id` (`training_dataset_id`),

--- a/files/default/sql/ddl/updates/1.3.0.sql
+++ b/files/default/sql/ddl/updates/1.3.0.sql
@@ -27,4 +27,18 @@ CREATE TABLE IF NOT EXISTS `feature_store_tag` (
 ALTER TABLE `hopsworks`.`host_services` CHANGE COLUMN `service` `name` varchar(48) COLLATE latin1_general_cs NOT NULL;
 ALTER TABLE `hopsworks`.`host_services` ADD UNIQUE KEY `service_UNIQUE` (`host_id`, `name`);
 
+<<<<<<< HEAD
 DELETE FROM `hopsworks`.`jobs` WHERE type="BEAM_FLINK";
+=======
+ALTER TABLE `hopsworks`.`training_dataset` ADD COLUMN `seed` BIGINT NULL;
+
+CREATE TABLE IF NOT EXISTS `training_dataset_split` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `training_dataset_id` int(11) NOT NULL,
+  `name` varchar(1000) COLLATE latin1_general_cs NOT NULL,
+  `percentage` float NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `training_dataset_id` (`training_dataset_id`),
+  CONSTRAINT `training_dataset_fk` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+>>>>>>> f4f1895... split changes

--- a/files/default/sql/ddl/updates/1.3.0.sql
+++ b/files/default/sql/ddl/updates/1.3.0.sql
@@ -34,7 +34,7 @@ ALTER TABLE `hopsworks`.`training_dataset` ADD COLUMN `seed` BIGINT NULL;
 CREATE TABLE IF NOT EXISTS `training_dataset_split` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `training_dataset_id` int(11) NOT NULL,
-  `name` varchar(1000) COLLATE latin1_general_cs NOT NULL,
+  `name` varchar(63) COLLATE latin1_general_cs NOT NULL,
   `percentage` float NOT NULL,
   PRIMARY KEY (`id`),
   KEY `training_dataset_id` (`training_dataset_id`),

--- a/files/default/sql/ddl/updates/1.3.0.sql
+++ b/files/default/sql/ddl/updates/1.3.0.sql
@@ -29,7 +29,7 @@ ALTER TABLE `hopsworks`.`host_services` ADD UNIQUE KEY `service_UNIQUE` (`host_i
 
 DELETE FROM `hopsworks`.`jobs` WHERE type="BEAM_FLINK";
 
-ALTER TABLE `hopsworks`.`training_dataset` ADD COLUMN `seed` BIGINT NULL;
+ALTER TABLE `hopsworks`.`training_dataset` ADD COLUMN `seed` BIGINT(11) NULL;
 
 CREATE TABLE IF NOT EXISTS `training_dataset_split` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/files/default/sql/ddl/updates/1.3.0.sql
+++ b/files/default/sql/ddl/updates/1.3.0.sql
@@ -27,9 +27,8 @@ CREATE TABLE IF NOT EXISTS `feature_store_tag` (
 ALTER TABLE `hopsworks`.`host_services` CHANGE COLUMN `service` `name` varchar(48) COLLATE latin1_general_cs NOT NULL;
 ALTER TABLE `hopsworks`.`host_services` ADD UNIQUE KEY `service_UNIQUE` (`host_id`, `name`);
 
-<<<<<<< HEAD
 DELETE FROM `hopsworks`.`jobs` WHERE type="BEAM_FLINK";
-=======
+
 ALTER TABLE `hopsworks`.`training_dataset` ADD COLUMN `seed` BIGINT NULL;
 
 CREATE TABLE IF NOT EXISTS `training_dataset_split` (
@@ -41,4 +40,3 @@ CREATE TABLE IF NOT EXISTS `training_dataset_split` (
   KEY `training_dataset_id` (`training_dataset_id`),
   CONSTRAINT `training_dataset_fk` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
->>>>>>> f4f1895... split changes

--- a/files/default/sql/ddl/updates/undo/1.3.0__undo.sql
+++ b/files/default/sql/ddl/updates/undo/1.3.0__undo.sql
@@ -12,3 +12,7 @@ DROP TABLE IF EXISTS `feature_store_tag`;
 
 ALTER TABLE `hopsworks`.`host_services` DROP KEY `service_UNIQUE`;
 ALTER TABLE `hopsworks`.`host_services` CHANGE COLUMN `name` `service` varchar(48) COLLATE latin1_general_cs NOT NULL;
+
+ALTER TABLE `hopsworks`.`training_dataset` DROP COLUMN `seed`;
+
+DROP TABLE IF EXISTS `training_dataset_split`;


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1678
https://bbc1.sics.se/jenkins/job/Hopsworks-testing-ee/189/