### PR TITLE
[HOPSWORKS-1929] enforce unique names in training dataset splits

### DIFF
--- a/files/default/sql/ddl/1.4.0__initial_tables.sql
+++ b/files/default/sql/ddl/1.4.0__initial_tables.sql
@@ -1561,7 +1561,10 @@ CREATE TABLE IF NOT EXISTS `training_dataset_split` (
   `percentage` float NOT NULL,
   PRIMARY KEY (`id`),
   KEY `training_dataset_id` (`training_dataset_id`),
-  CONSTRAINT `training_dataset_fk` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `dataset_id_split_name` (`training_dataset_id`, `name`),
+  CONSTRAINT `training_dataset_fk` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE
+   CASCADE ON UPDATE NO ACTION
+
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/files/default/sql/ddl/1.4.0__initial_tables.sql
+++ b/files/default/sql/ddl/1.4.0__initial_tables.sql
@@ -1797,8 +1797,7 @@ CREATE TABLE IF NOT EXISTS `feature_store_s3_connector` (
   `description`                         VARCHAR(1000)   NULL,
   `name`                                VARCHAR(1000)   NOT NULL,
   `server_encryption_algorithm`         INT(11)         NULL,
-  `server_encryption_key`               VARCHAR(1000)   NULL
-
+  `server_encryption_key`               VARCHAR(1000)   NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `s3_connector_featurestore_fk` FOREIGN KEY (`feature_store_id`) REFERENCES `hopsworks`.`feature_store` (`id`)
     ON DELETE CASCADE

--- a/files/default/sql/ddl/updates/1.4.0.sql
+++ b/files/default/sql/ddl/updates/1.4.0.sql
@@ -48,3 +48,6 @@ ALTER TABLE `hopsworks`.`conda_commands` DROP COLUMN `docker_image`;
 
 ALTER TABLE `hopsworks`.`feature_store_s3_connector` ADD COLUMN `server_encryption_algorithm` INT(11) DEFAULT NULL ;
 ALTER TABLE `hopsworks`.`feature_store_s3_connector` ADD COLUMN `server_encryption_key` VARCHAR(1000) DEFAULT NULL;
+
+ALTER TABLE `hopsworks`.`training_dataset_split` ADD UNIQUE KEY `dataset_id_split_name` (`training_dataset_id`, `name`);
+

--- a/files/default/sql/ddl/updates/undo/1.4.0__undo.sql
+++ b/files/default/sql/ddl/updates/undo/1.4.0__undo.sql
@@ -58,3 +58,5 @@ ALTER TABLE `hopsworks`.`conda_commands` ADD COLUMN `docker_image` varchar(255) 
 
 ALTER TABLE `hopsworks`.`feature_store_s3_connector` DROP COLUMN `server_encryption_algorithm`;
 ALTER TABLE `hopsworks`.`feature_store_s3_connector` DROP COLUMN `server_encryption_key`;
+
+ALTER TABLE `hopsworks`.`training_dataset_split` DROP INDEX `dataset_id_split_name`;


### PR DESCRIPTION
The changes for feature_store_s3_connector are for issue HOPSWORKS-1592