### PR TITLE
[HOPSWORKS-1918] Spark executor memory not modifiable from UI when starting jupyter fix

### DIFF
--- a/templates/default/sql/dml/2.0.0.sql.erb
+++ b/templates/default/sql/dml/2.0.0.sql.erb
@@ -1,1 +1,3 @@
 REPLACE INTO `hopsworks`.`variables`(`id`, `value`) VALUES ("rmyarn_user", "<%= node['hops']['rm']['user'] %>");
+
+REPLACE INTO `hopsworks`.`variables` (`id`, `value`) VALUES ("spark_executor_min_memory", 1024);

--- a/templates/default/sql/dml/undo/2.0.0__undo.sql.erb
+++ b/templates/default/sql/dml/undo/2.0.0__undo.sql.erb
@@ -1,1 +1,3 @@
 DELETE FROM `hopsworks`.`variables` WHERE `id`='rmyarn_user';
+
+DELETE FROM `hopsworks`.`variables` WHERE `id`='spark_executor_min_memory';


### PR DESCRIPTION
https://logicalclocks.atlassian.net/jira/software/c/projects/HOPSWORKS/issues/HOPSWORKS-1918