### PR TITLE
[HOPSWORKS-2057] Drop condacommands-project fk

### DIFF
--- a/files/default/sql/ddl/2.0.0__initial_tables.sql
+++ b/files/default/sql/ddl/2.0.0__initial_tables.sql
@@ -175,7 +175,6 @@ CREATE TABLE `conda_commands` (
   `error_message` VARCHAR(11000) COLLATE latin1_general_cs DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `project_id` (`project_id`),
-  CONSTRAINT `FK_284_520` FOREIGN KEY (`project_id`) REFERENCES `project` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `user_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`uid`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster AUTO_INCREMENT=32 DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/files/default/sql/ddl/updates/2.0.0.sql
+++ b/files/default/sql/ddl/updates/2.0.0.sql
@@ -27,3 +27,9 @@ ALTER TABLE `hopsworks`.`feature_store_s3_connector` DROP COLUMN `secret_key`;
 ALTER TABLE `hopsworks`.`feature_store_s3_connector` MODIFY `name` VARCHAR(150) COLLATE latin1_general_cs  NOT NULL;
 
 ALTER TABLE `hopsworks`.`secrets` MODIFY `secret_name` VARCHAR(200) COLLATE latin1_general_cs  NOT NULL;
+
+SET @fk_name = (SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = "hopsworks" AND TABLE_NAME = "conda_commands" AND REFERENCED_TABLE_NAME="project");
+SET @s := concat('ALTER TABLE hopsworks.conda_commands DROP FOREIGN KEY `', @fk_name, '`');
+PREPARE stmt1 FROM @s;
+EXECUTE stmt1;
+DEALLOCATE PREPARE stmt1;

--- a/files/default/sql/ddl/updates/undo/2.0.0__undo.sql
+++ b/files/default/sql/ddl/updates/undo/2.0.0__undo.sql
@@ -27,3 +27,5 @@ ALTER TABLE `hopsworks`.`feature_store_s3_connector` ADD COLUMN `secret_key` VAR
 ALTER TABLE `hopsworks`.`feature_store_s3_connector` MODIFY `name` VARCHAR(1000) COLLATE latin1_general_cs  NOT NULL;
 
 ALTER TABLE `hopsworks`.`secrets` MODIFY `secret_name` VARCHAR(125) COLLATE latin1_general_cs  NOT NULL;
+
+ALTER TABLE `hopsworks`.`conda_commands` ADD CONSTRAINT `FK_284_520` FOREIGN KEY (`project_id`) REFERENCES `project` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION ;


### PR DESCRIPTION
When a project is deleted, there need to be "REMOVE" commands left in the table but with the FK constraint these commands would be deleted by the db. Hopsworks ensures that any stray commands will be eventually removed (details in the Hopsworks PR of this JIRA)