### PR TITLE
[HOPSWORKS-2280] Save statistics configuration also for training datasets

### DIFF
--- a/files/default/sql/ddl/2.1.0__initial_tables.sql
+++ b/files/default/sql/ddl/2.1.0__initial_tables.sql
@@ -329,13 +329,6 @@ CREATE TABLE `feature_group` (
   `feature_group_type` INT(11) NOT NULL DEFAULT '0',
   `on_demand_feature_group_id` INT(11) NULL,
   `cached_feature_group_id` INT(11) NULL,
-  `desc_stats_enabled` TINYINT(1) NOT NULL DEFAULT '1',
-  `feat_corr_enabled` TINYINT(1) NOT NULL DEFAULT '1',
-  `feat_hist_enabled` TINYINT(1) NOT NULL DEFAULT '1',
-  `cluster_analysis_enabled` TINYINT(1) NOT NULL DEFAULT '1',
-  `num_clusters` int(11) NOT NULL DEFAULT '5',
-  `num_bins` INT(11) NOT NULL DEFAULT '20',
-  `corr_method` VARCHAR(50) NOT NULL DEFAULT 'pearson',
   PRIMARY KEY (`id`),
   UNIQUE KEY `name_version` (`feature_store_id`, `name`, `version`),
   KEY `feature_store_id` (`feature_store_id`),
@@ -350,6 +343,27 @@ CREATE TABLE `feature_group` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `statistics_config`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `statistics_config` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `feature_group_id` int(11),
+  `training_dataset_id` int(11),
+  `descriptive` TINYINT(1) NOT NULL DEFAULT '1',
+  `correlations` TINYINT(1) NOT NULL DEFAULT '1',
+  `histograms` TINYINT(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`),
+  KEY `feature_group_id` (`feature_group_id`),
+  KEY `training_dataset_id` (`training_dataset_id`),
+  CONSTRAINT `fg_statistics_config_fk` FOREIGN KEY (`feature_group_id`) REFERENCES `feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `td_statistics_config_fk` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `statistic_columns`
 --
 
@@ -357,11 +371,11 @@ CREATE TABLE `feature_group` (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `statistic_columns` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `feature_group_id` int(11) DEFAULT NULL,
+  `statistics_config_id` int(11),
   `name` varchar(500) COLLATE latin1_general_cs DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `feature_group_id` (`feature_group_id`),
-  CONSTRAINT `statistic_column_fk` FOREIGN KEY (`feature_group_id`) REFERENCES `feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  KEY `statistics_config_id` (`statistics_config_id`),
+  CONSTRAINT `statistics_config_fk` FOREIGN KEY (`statistics_config_id`) REFERENCES `statistics_config` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/files/default/sql/ddl/updates/2.1.0.sql
+++ b/files/default/sql/ddl/updates/2.1.0.sql
@@ -178,3 +178,74 @@ SET SQL_SAFE_UPDATES = 1;
 ALTER TABLE `hopsworks`.`project` DROP COLUMN `conda`;
 
 ALTER TABLE `hopsworks`.`project` DROP COLUMN `python_version`;
+
+CREATE TABLE `statistics_config` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `feature_group_id` int(11),
+  `training_dataset_id` int(11),
+  `descriptive` TINYINT(1) NOT NULL DEFAULT '1',
+  `correlations` TINYINT(1) NOT NULL DEFAULT '0',
+  `histograms` TINYINT(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `feature_group_id` (`feature_group_id`),
+  KEY `training_dataset_id` (`training_dataset_id`),
+  CONSTRAINT `fg_statistics_config_fk` FOREIGN KEY (`feature_group_id`) REFERENCES `feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `td_statistics_config_fk` FOREIGN KEY (`training_dataset_id`) REFERENCES `training_dataset` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+
+INSERT INTO `hopsworks`.`statistics_config` (`feature_group_id`, `descriptive`, `correlations`, `histograms`)
+SELECT `id` as `feature_group_id`,
+       `desc_stats_enabled` as `descriptive`,
+       `feat_corr_enabled` as `correlations`,
+       `feat_hist_enabled` as `histograms`
+    FROM `hopsworks`.`feature_group`;
+
+ALTER TABLE `hopsworks`.`feature_group`
+    DROP COLUMN `desc_stats_enabled`,
+    DROP COLUMN `feat_corr_enabled`,
+    DROP COLUMN `feat_hist_enabled`;
+
+drop procedure if exists schema_change;
+delimiter ';;'
+create procedure schema_change() begin
+
+ /* delete columns if they exist */
+ if exists (select * from information_schema.columns where table_name = 'feature_group' and column_name = 'cluster_analysis_enabled') then
+  alter table `hopsworks`.`feature_group` drop column `cluster_analysis_enabled`;
+ end if;
+ if exists (select * from information_schema.columns where table_name = 'feature_group' and column_name = 'num_clusters') then
+  alter table `hopsworks`.`feature_group` drop column `num_clusters`;
+ end if;
+ if exists (select * from information_schema.columns where table_name = 'feature_group' and column_name = 'num_bins') then
+  alter table `hopsworks`.`feature_group` drop column `num_bins`;
+ end if;
+ if exists (select * from information_schema.columns where table_name = 'feature_group' and column_name = 'corr_method') then
+  alter table `hopsworks`.`feature_group` drop column `corr_method`;
+ end if;
+
+end;;
+
+delimiter ';'
+call schema_change();
+drop procedure if exists schema_change;
+
+INSERT INTO `hopsworks`.`statistics_config` (`training_dataset_id`, `descriptive`, `correlations`, `histograms`)
+SELECT `id` as `training_dataset_id`,
+       1 as `descriptive`,
+       0 as `correlations`,
+       0 as `histograms`
+    FROM `hopsworks`.`training_dataset`;
+
+ALTER TABLE `hopsworks`.`statistic_columns`
+  DROP KEY `feature_group_id`,
+  DROP FOREIGN KEY `statistic_column_fk`,
+  ADD COLUMN `statistics_config_id` int(11) after `id`,
+  ADD KEY `statistics_config_id` (`statistics_config_id`),
+  ADD CONSTRAINT `statistics_config_fk` FOREIGN KEY (`statistics_config_id`) REFERENCES `statistics_config` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+SET SQL_SAFE_UPDATES = 0;
+UPDATE `hopsworks`.`statistics_config` `sc` INNER JOIN `hopsworks`.`statistic_columns` `col` ON `sc`.`feature_group_id` = `col`.`feature_group_id`
+SET `col`.`statistics_config_id` =  `sc`.`id`;
+SET SQL_SAFE_UPDATES = 1;
+
+ALTER TABLE `hopsworks`.`statistic_columns` DROP COLUMN `feature_group_id`;

--- a/files/default/sql/ddl/updates/undo/2.1.0__undo.sql
+++ b/files/default/sql/ddl/updates/undo/2.1.0__undo.sql
@@ -133,3 +133,31 @@ ALTER TABLE `hopsworks`.`python_environment` DROP FOREIGN KEY `FK_PYTHONENV_PROJ
 ALTER TABLE `hopsworks`.`project` DROP COLUMN `python_env_id`;
 
 DROP TABLE IF EXISTS `hopsworks`.`python_environment`;
+
+ALTER TABLE `hopsworks`.`feature_group`
+    ADD COLUMN `desc_stats_enabled` TINYINT(1) NOT NULL DEFAULT '1',
+    ADD COLUMN `feat_corr_enabled` TINYINT(1) NOT NULL DEFAULT '1',
+    ADD COLUMN `feat_hist_enabled` TINYINT(1) NOT NULL DEFAULT '1';
+
+SET SQL_SAFE_UPDATES = 0;
+UPDATE `hopsworks`.`feature_group` `fg` INNER JOIN `hopsworks`.`statistics_config` `sc` ON `fg`.`id` = `sc`.`feature_group_id`
+SET `fg`.`desc_stats_enabled` =  `sc`.`descriptive`,
+    `fg`.`feat_corr_enabled` = `sc`.`correlations`,
+    `fg`.`feat_hist_enabled` = `sc`.`histograms`;
+SET SQL_SAFE_UPDATES = 1;
+
+ALTER TABLE `hopsworks`.`statistic_columns`
+  DROP KEY `statistics_config_id`,
+  DROP FOREIGN KEY `statistics_config_fk`,
+  ADD COLUMN `feature_group_id` int(11) after `id`,
+  ADD KEY `feature_group_id` (`feature_group_id`),
+  ADD CONSTRAINT `statistic_column_fk` FOREIGN KEY (`feature_group_id`) REFERENCES `feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+SET SQL_SAFE_UPDATES = 0;
+UPDATE `hopsworks`.`statistics_config` `sc` INNER JOIN `hopsworks`.`statistic_columns` `col` ON `sc`.`id` = `col`.`statistics_config_id`
+SET `col`.`feature_group_id` =  `sc`.`feature_group_id`;
+SET SQL_SAFE_UPDATES = 1;
+
+ALTER TABLE `hopsworks`.`statistic_columns` DROP COLUMN `statistics_config_id`;
+
+DROP TABLE `hopsworks`.`statistics_config`;


### PR DESCRIPTION
There is one issue @SirOibaf the following columns should have been removed in the 2.0 release. Probably a bad refactor. they don't hurt in the table, however, I add drop column statements for them in the 2.1.0 update sql, which will fail if they exist. I am wondering if we should just leave them for 2.0 clusters or fix the release branch etc?

```
  `cluster_analysis_enabled` TINYINT(1) NOT NULL DEFAULT '1',
  `num_clusters` int(11) NOT NULL DEFAULT '5',
  `num_bins` INT(11) NOT NULL DEFAULT '20',
  `corr_method` VARCHAR(50) NOT NULL DEFAULT 'pearson',
```