### PR TITLE
[HOPSWORKS-2723] Remove AUDITOR role

### DIFF
--- a/templates/default/sql/dml/0.1.0.sql.erb
+++ b/templates/default/sql/dml/0.1.0.sql.erb
@@ -4,7 +4,6 @@
 --
 
 REPLACE INTO `bbc_group` (`group_name`, `group_desc`, `gid`) VALUES
-('AUDITOR','Auditors for the platform',1004),
 ('HOPS_ADMIN', 'System administrator', 1005),
 ('HOPS_USER', 'Registered users in the system', 1006),
 ('AGENT', 'Secret Agents in the system', 1007)

--- a/templates/default/sql/dml/3.0.0.sql.erb
+++ b/templates/default/sql/dml/3.0.0.sql.erb
@@ -4,3 +4,5 @@ REPLACE INTO `hopsworks`.`variables` VALUES ("kube_serving_node_tolerations", "<
 DELETE FROM `hopsworks`.`variables` WHERE id="ndb_dir";
 DELETE FROM `hopsworks`.`variables` WHERE id="mysql_dir";
 DELETE FROM `hopsworks`.`variables` WHERE id="mysql_user";
+
+DELETE FROM `hopsworks`.`bbc_group` WHERE group_name="AUDITOR";


### PR DESCRIPTION
The auditor role is not used anymore and should be removed.