### PR TITLE
[HOPSWORKS-2837] Extend query field size for SQL based on-demand feat…

### DIFF
--- a/files/default/sql/ddl/2.5.0__initial_tables.sql
+++ b/files/default/sql/ddl/2.5.0__initial_tables.sql
@@ -1726,7 +1726,7 @@ CREATE TABLE IF NOT EXISTS `feature_store_connector` (
 
 CREATE TABLE IF NOT EXISTS `on_demand_feature_group` (
                                                          `id`                      INT(11)         NOT NULL AUTO_INCREMENT,
-                                                         `query`                   VARCHAR(11000),
+                                                         `query`                   VARCHAR(26000),
                                                          `connector_id`            INT(11)         NOT NULL,
                                                          `description`             VARCHAR(1000)   NULL,
                                                          `inode_pid`               BIGINT(20)      NOT NULL,

--- a/files/default/sql/ddl/updates/2.5.0.sql
+++ b/files/default/sql/ddl/updates/2.5.0.sql
@@ -21,3 +21,5 @@ CREATE TABLE `cached_feature` (
   KEY `cached_feature_group_fk` (`cached_feature_group_id`),
   CONSTRAINT `cached_feature_group_fk2` FOREIGN KEY (`cached_feature_group_id`) REFERENCES `cached_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+
+ALTER TABLE `hopsworks`.`on_demand_feature_group` MODIFY COLUMN `query` VARCHAR(26000) COLLATE latin1_general_cs DEFAULT NULL;

--- a/files/default/sql/ddl/updates/undo/2.5.0__undo.sql
+++ b/files/default/sql/ddl/updates/undo/2.5.0__undo.sql
@@ -7,3 +7,5 @@ ALTER TABLE `hopsworks`.`serving` DROP COLUMN `model_name`;
 ALTER TABLE `hopsworks`.`executions` ADD CONSTRAINT `FK_347_365`  FOREIGN KEY (`job_id`) REFERENCES `hopsworks`.`jobs` (`id`) ON DELETE CASCADE;
 
 DROP TABLE `hopsworks`.`cached_feature`;
+
+ALTER TABLE `hopsworks`.`on_demand_feature_group` MODIFY COLUMN `query` VARCHAR(11000) COLLATE latin1_general_cs DEFAULT NULL;


### PR DESCRIPTION
…ure group

Size of the query field can be extended to 26KB (from 11KB). Space
remains for additional fields that we might add to the
`on_demand_feature_group` table in the future