### PR TITLE
[HWORKS-456] Re-organize ddl statements

### DIFF
--- a/files/default/sql/ddl/updates/3.1.0.sql
+++ b/files/default/sql/ddl/updates/3.1.0.sql
@@ -10,11 +10,12 @@ ALTER TABLE `hopsworks`.`python_dep` ADD COLUMN `repo_url` varchar(255) CHARACTE
 SET SQL_SAFE_UPDATES = 0;
 UPDATE python_dep p SET repo_url=(SELECT url FROM anaconda_repo WHERE id = p.repo_id);
 SET SQL_SAFE_UPDATES = 1;
-alter table `hopsworks`.`python_dep` drop foreign key `FK_501_510`, drop column `repo_id`;
-alter table `hopsworks`.`python_dep` drop index `dependency`;
-DROP TABLE `anaconda_repo`;
+ALTER TABLE `hopsworks`.`python_dep` DROP FOREIGN KEY `FK_501_510`;
+ALTER TABLE `hopsworks`.`python_dep` DROP INDEX `dependency`;
 ALTER TABLE `hopsworks`.`python_dep` ADD CONSTRAINT `dependency` UNIQUE (`dependency`,`version`,`install_type`,
                                                                          `repo_url`);
+ALTER TABLE `hopsworks`.`python_dep` DROP COLUMN `repo_id`;
+DROP TABLE `anaconda_repo`;
 
 -- add tutorial endpoint
 CREATE TABLE IF NOT EXISTS `tutorial` (

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -343,7 +343,10 @@ bash "flyway_migrate" do
   user "root"
   cwd "#{theDomain}/flyway"
   code <<-EOF
-    #{theDomain}/flyway/flyway migrate
+    # Validation during migrate is very strict for our needs. If we found a bug
+    # on a released branch and we fix it, next time someone upgrades to released branch+1
+    # they will get a validation error because the files checksum do not match
+    #{theDomain}/flyway/flyway -validateOnMigrate=false migrate
   EOF
 end
 


### PR DESCRIPTION
[HWORKS-456] Disable validation of sql ddl files during migration

[HWORKS-456]: https://hopsworks.atlassian.net/browse/HWORKS-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ