### PR TITLE
[CLOUD-445] Hopsworks configuration parameter with unix usernames

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -129,6 +129,14 @@ default['hopsworks']['pki']['root']['name']             = ""
 default['hopsworks']['pki']['root']['duration']         = "3650d"
 default['hopsworks']['pki']['intermediate']['name']     = ""
 default['hopsworks']['pki']['intermediate']['duration'] = "3650d"
+## Additionally to Consul domain names add these as DNS SAN when generating a certificate for a system user
+## It should be a valid JSON object with the following format:
+## {
+##   "USERNAME such as hdfs": {
+##     "dns": ["EXTRA_DOMAINS"]
+##   }
+## }
+default['hopsworks']['pki']['intermediate']['extra_san_for_username'] = ""
 default['hopsworks']['pki']['kubernetes']['name']       = ""
 default['hopsworks']['pki']['kubernetes']['duration']   = "3650d"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -183,6 +183,10 @@ attribute "hopsworks/pki/intermediate/duration",
           :description => "Validity period for Intermediate CA. Valid suffixes: s, m, h, d",
           :type => 'string'
 
+attribute "hopsworks/pki/intermediate/extra_san_for_username",
+          :description => "Configurable extra DNS SAN for system users such as hdfs. Check attributes/default.rb for the correct format",
+          :type => 'string'
+
 attribute "hopsworks/pki/kubernetes/name",
           :description => "X.509 Subject name for Kubernetes CA",
           :type => 'string'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -263,6 +263,7 @@ usernamesConfiguration[:hopsmon] = node['hopsmonitor']['user']
 usernamesConfiguration[:zookeeper] = node['kzookeeper']['user']
 usernamesConfiguration[:onlinefs] = node['onlinefs']['user']
 usernamesConfiguration[:elastic] = node['elastic']['user']
+usernamesConfiguration[:kagent] = node['kagent']['user']
 if node.attribute?('flyingduck') && node['flyingduck'].attribute?('user')
   usernamesConfiguration[:flyingduck] = node['flyingduck']['user']
 end

--- a/templates/default/sql/dml/3.3.0.sql.erb
+++ b/templates/default/sql/dml/3.3.0.sql.erb
@@ -1,1 +1,2 @@
 REPLACE INTO `hopsworks`.`variables`(`id`, `value`, `visibility`) VALUES ("docker_cgroup_parent", "<%= node['hops']['docker']['cgroup']['parent'] %>", 1);
+REPLACE INTO `hopsworks`.`variables`(`id`, `value`) VALUES('unix_usernames_conf', '<%= @usernames_configuration %>');


### PR DESCRIPTION
[CLOUD-445] Change subject of glassfish internal certificate to accomodate multiple instances

[CLOUD-445] Configuration for extra SAN for users

[CLOUD-445] Parse json instead of just string

[CLOUD-445]: https://hopsworks.atlassian.net/browse/CLOUD-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-445]: https://hopsworks.atlassian.net/browse/CLOUD-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-445]: https://hopsworks.atlassian.net/browse/CLOUD-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ