### PR TITLE
[FSTORE-709] add stream fg key to cached_feature_extra_constraints

### DIFF
--- a/files/default/sql/ddl/3.3.0__initial_tables.sql
+++ b/files/default/sql/ddl/3.3.0__initial_tables.sql
@@ -1913,6 +1913,8 @@ CREATE TABLE `cached_feature_extra_constraints` (
                                                     `hudi_precombine_key` tinyint(1) NOT NULL DEFAULT '0',
                                                     PRIMARY KEY (`id`),
                                                     KEY `cached_feature_group_fk` (`cached_feature_group_id`),
+                                                    KEY `stream_feature_group_fk` (`stream_feature_group_id`),
+                                                    CONSTRAINT `stream_feature_group_fk1` FOREIGN KEY (`stream_feature_group_id`) REFERENCES `stream_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
                                                     CONSTRAINT `cached_feature_group_fk1` FOREIGN KEY (`cached_feature_group_id`) REFERENCES `cached_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 

--- a/files/default/sql/ddl/updates/3.3.0.sql
+++ b/files/default/sql/ddl/updates/3.3.0.sql
@@ -143,3 +143,8 @@ ALTER TABLE `hopsworks`.`hdfs_command_execution` ADD COLUMN `src_path` VARCHAR(1
 ALTER TABLE `hopsworks`.`hdfs_command_execution` ADD UNIQUE KEY `uq_src_path` (`src_path`);
 -- FSTORE-577
 ALTER TABLE `hopsworks`.`feature_store_s3_connector` ADD COLUMN `arguments` VARCHAR(2000) DEFAULT NULL;
+
+--FSTORE-709
+ALTER TABLE `cached_feature_extra_constraints` ADD KEY stream_feature_group_fk (`stream_feature_group_id`);
+ALTER TABLE `cached_feature_extra_constraints` ADD CONSTRAINT `stream_feature_group_fk1` FOREIGN KEY (`stream_feature_group_id`) REFERENCES `stream_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+


### PR DESCRIPTION
foreign key of `stream_feature_group_id` is missing in the talble `cached_feature_extra_constraints`