### PR TITLE
[HWORKS-1058] Migrate should run after default recipe

### DIFF
--- a/Karamelfile
+++ b/Karamelfile
@@ -23,6 +23,9 @@ dependencies:
     global:
       - hops::dn
       - hopslog::default
+      - hopsworks::default
+      - hopsworks::das_node
+      - hopsworks::config_node
   - recipe: hopsworks::das_node
     local:
       - hopsworks::default


### PR DESCRIPTION
* [HWORKS-1058] Migrate should run after default recipe

* [HWORKS-1058] Move migrate after DAS and Config node

[HWORKS-1058]: https://hopsworks.atlassian.net/browse/HWORKS-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-1058]: https://hopsworks.atlassian.net/browse/HWORKS-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ